### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/burrito-consumers/15e785a6-3a6b-4483-8bbe-3f97cb01cedb/7083add5-0ffb-4ad5-a084-25811b5cb0f1/_apis/work/boardbadge/6f2a56d0-ae98-4228-8633-4d5118163819)](https://dev.azure.com/burrito-consumers/15e785a6-3a6b-4483-8bbe-3f97cb01cedb/_boards/board/t/7083add5-0ffb-4ad5-a084-25811b5cb0f1/Microsoft.RequirementCategory)
 This repo contains json files for System76 Launch keyboard. Files that may pertain to configs for games, etc. Enjoy.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/burrito-consumers/15e785a6-3a6b-4483-8bbe-3f97cb01cedb/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.